### PR TITLE
fix win can not compile

### DIFF
--- a/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
+++ b/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
@@ -301,9 +301,9 @@ void DataReaderHelper::addDataFromFile(const std::string& filePath)
 
     // Read content from file
     std::string fullPath = FileUtils::getInstance()->fullPathForFilename(filePath);
-    bool isbinarysrc = str==".csb";
+    bool isbinaryfilesrc = str==".csb";
     std::string filemode("r");
-    if(isbinarysrc)
+    if(isbinaryfilesrc)
         filemode += "b";
     ssize_t filesize;
     
@@ -324,7 +324,7 @@ void DataReaderHelper::addDataFromFile(const std::string& filePath)
     {
         DataReaderHelper::addDataFromJsonCache(contentStr, &dataInfo);
     }
-    else if(str == ".csb")
+    else if(isbinaryfilesrc)
     {
         DataReaderHelper::addDataFromBinaryCache(contentStr.c_str(),&dataInfo);
     }
@@ -438,7 +438,7 @@ void DataReaderHelper::addDataFromFileAsync(const std::string& imagePath, const 
     {
         data->configType = CocoStudio_JSON;
     }
-    else if(str == ".csb")
+    else if(isbinaryfilesrc)
     {
         data->configType = CocoStudio_Binary;
     }

--- a/cocos/editor-support/cocostudio/proj.win32/libCocosStudio.vcxproj
+++ b/cocos/editor-support/cocostudio/proj.win32/libCocosStudio.vcxproj
@@ -188,7 +188,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>
       </SDLCheck>
-      <AdditionalIncludeDirectories>$(EngineRoot);$(EngineRoot)cocos;$(EngineRoot)cocos\audio\include;$(EngineRoot)cocos\editor-support;$(EngineRoot)external;$(EngineRoot)external\tinyxml2;$(EngineRoot)external\chipmunk\include\chipmunk;$(EngineRoot)extensions;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(EngineRoot);$(EngineRoot)cocos;$(EngineRoot)cocos\audio\include;$(EngineRoot)cocos\editor-support;$(EngineRoot)external;$(EngineRoot)external\tinyxml2;$(EngineRoot)external\chipmunk\include\chipmunk;$(EngineRoot)extensions;$(EngineRoot)external\win32-specific\zlib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_LIB;COCOS2DXWIN32_EXPORTS;GL_GLEXT_PROTOTYPES;COCOS2D_DEBUG=1;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4267;4251;4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>


### PR DESCRIPTION
fix win can not compile

*\*  must replace the csb files in ccs-res/ and ccs-res/hd use the new ones generate by new binaryconvert tools  **
now new binary files can work in cpp-tests
